### PR TITLE
fix name for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "BrandButtons",
+  "name": "brandbuttons",
   "version": "0.2.0",
   "homepage": "https://github.com/theaqua/BrandButtons",
   "authors": [


### PR DESCRIPTION
bower install
bower BrandButtons#0.2      not-cached git://github.com/theaqua/BrandButtons.git#0.2
bower BrandButtons#0.2         resolve git://github.com/theaqua/BrandButtons.git#0.2
bower BrandButtons#0.2        download https://github.com/theaqua/BrandButtons/archive/0.2.tar.gz
bower BrandButtons#0.2         extract archive.tar.gz
bower BrandButtons#0.2        EINVALID Failed to read /var/folders/1t/y1l91wl10c1dzz3682wqvnxh0000gn/T/moi/bower/BrandButtons-60024-S4pgKb/bower.json

Additional error details:
The name contains upper case letters